### PR TITLE
Make NL_{SAVE,RESTORE}_WERROR Sensitive to and Handle -Werror=<specific>

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
-1.4.3 (2017-06-28)
+1.4.3 (2018-02-01)
 
-	* First public release to Github.
+        * Addressed an issue with NL_{SAVE,RESTORE}_WERROR in which
+          -Werror=<specific> was not handled.
 
 1.4.2 (2017-06-20)
 

--- a/autoconf/m4/nl_werror.m4
+++ b/autoconf/m4/nl_werror.m4
@@ -1,5 +1,5 @@
 #
-#    Copyright 2015-2016 Nest Labs Inc. All Rights Reserved.
+#    Copyright 2015-2018 Nest Labs Inc. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -17,12 +17,13 @@
 #
 #    Description:
 #      This file defines GNU autoconf M4-style macros that ensure the
-#      -Werror compiler option for GCC-based or -compatible compilers
-#      do not break some autoconf tests (see
+#      -Werror (or -Werror=<...>) compiler option(s) for GCC-based or
+#      -compatible compilers do not break some autoconf tests (see
 #      http://lists.gnu.org/archive/html/autoconf-patches/2008-09/msg00014.html).
 #
-#      If -Werror has been passed transform it into -Wno-error for
-#      CPPFLAGS, CFLAGS, CXXFLAGS, OBJCFLAGS, and OBJCXXFLAGS with
+#      If -Werror (or -Werror=<...>) has/have been passed transform it
+#      into -Wno-error (or -Wno-error=<...>) for CPPFLAGS, CFLAGS,
+#      CXXFLAGS, OBJCFLAGS, and OBJCXXFLAGS with
 #      NL_SAVE_WERROR. Transform them back again with
 #      NL_RESTORE_WERROR.
 #
@@ -31,17 +32,19 @@
 # _NL_SAVE_WERROR_FOR_VAR(variable)
 #
 #   variable - The compiler flags variable to scan for the presence of
-#              -Werror and, if present, transform to -Wno-error.
+#              -Werror (or -Werror=<...>) and, if present, transform
+#              to -Wno-error (or -Wno-error=<...>).
 #
 # This transforms, for the specified compiler flags variable, -Werror
-# to -Wno-error, if it was it present. The original state may be
-# restored by invoking _NL_RESTORE_WERROR_FOR_VAR([variable]).
+# (or -Werror=<...>) to -Wno-error (or -Wno-error=<...>), if it was it
+# present. The original state may be restored by invoking
+# _NL_RESTORE_WERROR_FOR_VAR([variable]).
 #
 #------------------------------------------------------------------------------
 AC_DEFUN([_NL_SAVE_WERROR_FOR_VAR],
 [
     if echo "${$1}" | grep -q '\-Werror'; then
-	$1="`echo ${$1} | sed -e 's,-Werror\([[[:space:]]]\),-Wno-error\1,g'`"
+	$1="`echo ${$1} | sed -e 's,-Werror\(=[[[:alnum:]_-]]\+\)*\([[[:space:]]]\),-Wno-error\1\2,g'`"
 	nl_had_$1_werror=yes
     else
 	nl_had_$1_werror=no
@@ -56,14 +59,15 @@ AC_DEFUN([_NL_SAVE_WERROR_FOR_VAR],
 #              such.
 #
 # This restores, for the specified compiler flags variable, -Werror
-# from -Wno-error, if it was initially set as -Werror at the time
+# (or -Werror=<...>) from -Wno-error (or -Wno-error=<...>), if it was
+# initially set as -Werror (or -Werror=<...>) at the time
 # _NL_SAVE_WERROR_FOR_VAR([variable]) was invoked.
 #
 #------------------------------------------------------------------------------
 AC_DEFUN([_NL_RESTORE_WERROR_FOR_VAR],
 [
     if test "${nl_had_$1_werror}" = "yes"; then
-	$1="`echo ${$1} | sed -e 's,-Wno-error\([[[:space:]]]\),-Werror\1,g'`"
+	$1="`echo ${$1} | sed -e 's,-Wno-error\(=[[[:alnum:]_-]]\+\)*\([[[:space:]]]\),-Werror\1\2,g'`"
     fi
 
     unset nl_had_$1_werror
@@ -73,8 +77,9 @@ AC_DEFUN([_NL_RESTORE_WERROR_FOR_VAR],
 # NL_SAVE_WERROR
 #
 # This transforms, for each of CFLAGS, CXXFLAGS, OBJCFLAGS, and
-# OBJCXXFLAGS, -Werror to -Wno-error, if it was it present. The
-# original state may be restored by invoking NL_RESTORE_WERROR.
+# OBJCXXFLAGS, -Werror (or -Werror=<...>) to -Wno-error (or
+# -Wno-error=<...>), if it was it present. The original state may be
+# restored by invoking NL_RESTORE_WERROR.
 #
 #------------------------------------------------------------------------------
 AC_DEFUN([NL_SAVE_WERROR],
@@ -90,8 +95,9 @@ AC_DEFUN([NL_SAVE_WERROR],
 # NL_RESTORE_WERROR
 #
 # This restores, for each of OBJCXXFLAGS, OBJCFLAGS, CXXFLAGS, and
-# CFLAGS, -Werror from -Wno-error, if it was initially set as -Werror
-# at the time NL_SAVE_WERROR was invoked.
+# CFLAGS, -Werror (or -Werror=<...>) from -Wno-error (or
+# -Wno-error=<...>), if it was initially set as -Werror (or
+# -Werror=<...>) at the time NL_SAVE_WERROR was invoked.
 #
 #------------------------------------------------------------------------------
 AC_DEFUN([NL_RESTORE_WERROR],


### PR DESCRIPTION
This enhances NL_{SAVE,RESTORE}_WERROR such that it handles not only -Werror but also -Werror=<specific> such that autoconf compile tests may pass successfully when options such as -Werror=implicit -Werror=missing-prototypes -Werror=strict-prototypes are asserted.