### PR TITLE
nl_enable_coverage: -lcov is a LIB, not an LDFLAG

### DIFF
--- a/autoconf/m4/nl_enable_coverage.m4
+++ b/autoconf/m4/nl_enable_coverage.m4
@@ -91,7 +91,7 @@ AC_DEFUN([NL_ENABLE_COVERAGE],
 
                 else
                     NL_COVERAGE_CPPFLAGS="--coverage"
-                    NL_COVERAGE_LDFLAGS="-lgcov"            
+                    NL_COVERAGE_LIBS="-lgcov"
 
                 fi
             fi


### PR DESCRIPTION
Bug: Gcov builds fail with recent versions of gcc because gcov symbols fail
to be included in the binary.
Root cause: "-lgcov" is added at the beginning of the link command line,
because "-lgcov" is treaded as a flag instead of a library.
Fix: this commit moves "-lgcov" to NL_COVERAGE_LIBS from
NL_COVERAGE_LDFLAGS.

After this commit, configure.ac scripts will have to be updated as
follows:

diff --git a/configure.ac b/configure.ac
index 404d62b87..779848736 100644
--- a/configure.ac
+++ b/configure.ac
@@ -2319,7 +2319,7 @@ LIBS="${LIBS} ${NLFAULTINJECTION_LIBS}"
 # Add any code coverage CPPFLAGS and LDFLAGS

 CPPFLAGS="${CPPFLAGS} ${NL_COVERAGE_CPPFLAGS}"
-LDFLAGS="${LDFLAGS} ${NL_COVERAGE_LDFLAGS}"
+LIBS="${LIBS} ${NL_COVERAGE_LIBS}"