### PR TITLE
nl_enable_coverage: -lgcov is a LIB, not an LDFLAG

### DIFF
--- a/autoconf/m4/nl_enable_coverage.m4
+++ b/autoconf/m4/nl_enable_coverage.m4
@@ -32,7 +32,7 @@
 # whether the package will be built with or without code coverage.
 #
 # The value 'nl_cv_build_coverage' will be set to the result. In
-# addition, NL_COVERAGE_CPPFLAGS and NL_COVERAGE_LDFLAGS will be set
+# addition, NL_COVERAGE_CPPFLAGS and NL_COVERAGE_LIBS will be set
 # to the appropriate values to pass to the compiler and linker,
 # respectively.
 #

--- a/examples/configure.ac
+++ b/examples/configure.ac
@@ -303,10 +303,10 @@ if test "${ac_no_link}" != "yes"; then
     AC_CHECK_FUNCS([memcpy])
 fi
 
-# Add any code coverage CPPFLAGS and LDFLAGS
+# Add any code coverage CPPFLAGS and LIBS
 
 CPPFLAGS="${CPPFLAGS} ${NL_COVERAGE_CPPFLAGS}"
-LDFLAGS="${LDFLAGS} ${NL_COVERAGE_LDFLAGS}"
+LIBS="${LIBS} ${NL_COVERAGE_LIBS}"
 
 # At this point, we can restore the compiler flags to whatever the
 # user passed in, now that we're clear of an -Werror issues by


### PR DESCRIPTION
Re-fix the issue fixed in https://github.com/nestlabs/nlbuild-autotools/commit/154adb1beb6d30f8978e2ea3293204f70f8ed403