### PR TITLE
Fix autotools detection of -Wno-* compiler flags

### DIFF
--- a/autoconf/m4/ax_check_compiler.m4
+++ b/autoconf/m4/ax_check_compiler.m4
@@ -31,8 +31,16 @@ AC_DEFUN([_AX_CHECK_COMPILER_OPTION_WITH_VAR],
     AC_MSG_CHECKING([whether the _AC_LANG compiler understands $3])
     SAVE_[]_AC_LANG_PREFIX[]FLAGS=${_AC_LANG_PREFIX[]FLAGS}
     SAVE_$2=${$2}
-    _AC_LANG_PREFIX[]FLAGS=$3
+    AS_LITERAL_IF([$3],
+      [m4_pushdef([COMPILER_OPTION], m4_bpatsubst([$3], [^-Wno-], [-W]))],
+      [compiler_option="$3"
+    case $compiler_option in
+      -Wno-*) compiler_option=`echo ".$compiler_option" | sed 's/^.//; s/^-Wno-/-W/'`;;
+    esac
+    m4_pushdef([COMPILER_OPTION], [$compiler_option])])dnl
+    _AC_LANG_PREFIX[]FLAGS=m4_defn([COMPILER_OPTION])
     AC_TRY_COMPILE(,[;],AC_MSG_RESULT([yes]); _AC_LANG_PREFIX[]FLAGS="${SAVE_[]_AC_LANG_PREFIX[]FLAGS}"; $2="${SAVE_$2} $3",AC_MSG_RESULT([no]); _AC_LANG_PREFIX[]FLAGS=${SAVE_[]_AC_LANG_PREFIX[]FLAGS}; $2=${SAVE_$2});
+    m4_popdef([COMPILER_OPTION])dnl
     unset SAVE_[]_AC_LANG_PREFIX[]FLAGS
     unset SAVE_$2
     AC_LANG_POP($1)
@@ -53,8 +61,16 @@ AC_DEFUN([_AX_CHECK_COMPILER_OPTION],
     AC_LANG_PUSH($1)
     AC_MSG_CHECKING([whether the _AC_LANG compiler understands $2])
     SAVE_[]_AC_LANG_PREFIX[]FLAGS=${_AC_LANG_PREFIX[]FLAGS}
-    _AC_LANG_PREFIX[]FLAGS=$2
+    AS_LITERAL_IF([$2],
+      [m4_pushdef([COMPILER_OPTION], m4_bpatsubst([$2], [^-Wno-], [-W]))],
+      [compiler_option="$2"
+    case $compiler_option in
+      -Wno-*) compiler_option=`echo ".$compiler_option" | sed 's/^.//; s/^-Wno-/-W/'`;;
+    esac
+    m4_pushdef([COMPILER_OPTION], [$compiler_option])])dnl
+    _AC_LANG_PREFIX[]FLAGS=m4_defn([COMPILER_OPTION])
     AC_TRY_COMPILE(,[;],AC_MSG_RESULT([yes]); _AC_LANG_PREFIX[]FLAGS="${SAVE_[]_AC_LANG_PREFIX[]FLAGS} $2",AC_MSG_RESULT([no]); _AC_LANG_PREFIX[]FLAGS=${SAVE_[]_AC_LANG_PREFIX[]FLAGS});
+    m4_popdef([COMPILER_OPTION])dnl
     unset SAVE_[]_AC_LANG_PREFIX[]FLAGS
     AC_LANG_POP($1)
 ])


### PR DESCRIPTION
From gcc version 4.4, the manual states: "When an unrecognized warning option is requested
(e.g., -Wunknown-warning), GCC emits a diagnostic stating that the option is not recognized.
However, if the -Wno- form is used, the behavior is slightly different: no diagnostic is
produced for -Wno-unknown-warning unless other diagnostics are being produced."

This means that nlbuild-autotools won't detect invalid -Wno-* warning flags. As a
consequence, gcc will be passed some invalid -Wno-* options.

This commit adds code that passes the positive version of the warning flag during compiler
checks. For example, -Wno-some-warning will be passed as -Wsome-warning to the compiler
during ./configure, so the -Wno-some-warning flag doesn't get added incorrectly to CFLAGS.

The code is almost exactly the same as the one used by gnulib.