### PR TITLE
Add absolute path support for pretty

### DIFF
--- a/automake/post/rules/pretty.am
+++ b/automake/post/rules/pretty.am
@@ -47,8 +47,8 @@
 define nl-make-pretty
 $(AM_V_at)for file in $(4); do \
     $(1) \
-    if test -f $${file}; then d=.; else d=$(srcdir); fi; \
-    $(2) $(3) $${d}/$${file} \
+    if test -f $${file}; then d=; else d=$(srcdir)/; fi; \
+    $(2) $(3) $${d}$${file} \
     || exit 1; \
 done
 endef


### PR DESCRIPTION
This PR adds absolute path support for pretty target. This is useful
when the project is configure in a different directory with absolute
path to the configure script. Using absolute path of configure is very
help for code coverage tool to correctly find the source files.