### PR TITLE
MAKEDIRS reloaded

### DIFF
--- a/automake/post/rules/makedirs.am
+++ b/automake/post/rules/makedirs.am
@@ -31,11 +31,18 @@
 #        (all _OBJECTS) defined by a Makefile.am to depend upon an invocation
 #        of `$(MAKE) -C <DIR>` in that directory.
 #
+
+
+# same as ifdef MAKEDIRS || MAKEDIR_TARGETS
+ifneq ($(strip $(MAKEDIRS)$(MAKEDIR_TARGETS)),)
+
+makedirs_id:=makedirs_$(shell echo $$$$)
+
+endif # ifneq ($(strip $(MAKEDIRS)$(MAKEDIR_TARGETS)),)
+
 ifdef MAKEDIRS
 
-.PHONY: makedirs force
-
-force: # no rules, please always build ;)
+.PHONY: makedirs
 
 # The way we make a MAKEDIR
 define makedirs-make
@@ -54,16 +61,24 @@ $(foreach objects,$(filter %_OBJECTS,$(.VARIABLES)),\
    $(foreach object,$($(objects)),\
    $(eval $(call makedirs-depends,$(object)))))
 
-makedirs: force
+makedirs: $(makedirs_id)
 	$(foreach dir,$(MAKEDIRS),$(call makedirs-make,$(dir)))
+
+$(makedirs_id):
+	@touch $@
+	$(RM) $(filter-out $@,$(wildcard makedirs_*))
 
 endif # ifdef MAKEDIRS
 
 ifdef MAKEDIR_TARGETS
 # The way me make a MAKEDIR_TARGET
 define makedirs-makedir-target-rule
-$1: force
-	$(MAKE) -C $$(dir $$(@)) $$(notdir $$(@))
+$1: $(notdir $1).$(makedirs_id)
+	$(MAKE) -C $(dir $1) $(notdir $1)
+
+$(notdir $1).$(makedirs_id):
+	@touch $$@
+	@$(RM) $(filter-out $$@,$$(wildcard $(notdir $1).makedirs_*))
 endef # makedirs-makedir-target-rule
 
 $(foreach makedir_target,$(MAKEDIR_TARGETS),\

--- a/automake/post/rules/makedirs.am
+++ b/automake/post/rules/makedirs.am
@@ -56,11 +56,14 @@ ifdef MAKEDIRS
 
 .PHONY: makedirs
 
+ifeq ($(MAKECMDGOALS),$(filter-out clean distclean,$(MAKECMDGOALS)))
 # trick make into building makedirs first by forcing it to try to make an
 #  include file that depends on makedirs
 -include .makedirs_trick_never_exists.min
 
 .makedirs_trick_never_exists.min: makedirs
+
+endif # ifeq ($(MAKECMDGOALS),$(filter-out $(MAKECMDGOALS),clean distclean))
 
 
 # This says chunk says:
@@ -112,7 +115,7 @@ $1: $1.$(makedirs_id)
 
 $1.$(makedirs_id):
 	$(NL_V_AT)touch $$@
-	$(NL_V_AT)$(RM) $$(filter-out $$@,$$(wildcard $(notdir $1).makedirs_*))
+	$(NL_V_AT)$(RM) $$(filter-out $$@,$$(wildcard $1.makedirs_*))
 
 .PHONY: $1.makedirs_clean
 distclean clean: $1.makedirs_clean

--- a/automake/post/rules/makedirs.am
+++ b/automake/post/rules/makedirs.am
@@ -66,7 +66,7 @@ makedirs: $(makedirs_id)
 
 $(makedirs_id):
 	@touch $@
-	$(RM) $(filter-out $@,$(wildcard makedirs_*))
+	@$(RM) $(filter-out $@,$(wildcard makedirs_*))
 
 endif # ifdef MAKEDIRS
 

--- a/automake/post/rules/makedirs.am
+++ b/automake/post/rules/makedirs.am
@@ -56,17 +56,12 @@ ifdef MAKEDIRS
 
 .PHONY: makedirs
 
-# simple dependency make snippet, scoped to makedirs
-define makedirs-depends
-$1: | makedirs
+# trick make into building makedirs first by forcing it to try to make an
+#  include file that depends on makedirs
+-include .makedirs_trick_never_exists.min
 
-endef # makedirs-depends
+.makedirs_trick_never_exists.min: makedirs
 
-# Use brute force: before any compilation, all _OBJECTS depend on makedirs
-#  wish there were something in automake that meant "please do first"...
-$(foreach objects,$(filter %_OBJECTS,$(.VARIABLES)),\
-   $(foreach object,$($(objects)),\
-   $(eval $(call makedirs-depends,$(object)))))
 
 # This says chunk says:
 #  1. makedirs (the order-only PHONY target above) depends on the file
@@ -112,18 +107,18 @@ ifdef MAKEDIR_TARGETS
 #  3. clean and distclean should whack all makedir_id files that might
 #       have accumulated
 define makedirs-makedir-target-rules
-$1: $(notdir $1).$(makedirs_id)
+$1: $1.$(makedirs_id)
 	$(NL_V_AT)$(MAKE) -C $(dir $1) $(notdir $1)
 
-$(notdir $1).$(makedirs_id):
+$1.$(makedirs_id):
 	$(NL_V_AT)touch $$@
 	$(NL_V_AT)$(RM) $$(filter-out $$@,$$(wildcard $(notdir $1).makedirs_*))
 
-.PHONY: $(notdir $1).makedirs_clean
-distclean clean: $(notdir $1).makedirs_clean
+.PHONY: $1.makedirs_clean
+distclean clean: $1.makedirs_clean
 
-$(notdir $1).makedirs_clean:
-	$(NL_V_AT)$(RM) $$(wildcard $(notdir $1).makedirs_*)
+$1.makedirs_clean:
+	$(NL_V_AT)$(RM) $$(wildcard $1.makedirs_*)
 
 endef # makedirs-makedir-target-rules
 

--- a/automake/post/rules/makedirs.am
+++ b/automake/post/rules/makedirs.am
@@ -36,19 +36,25 @@
 # same as ifdef MAKEDIRS || MAKEDIR_TARGETS
 ifneq ($(strip $(MAKEDIRS)$(MAKEDIR_TARGETS)),)
 
-makedirs_id:=makedirs_$(shell echo $$$$)
+# check to see if makedirs_id has been set for this invocation
+ifneq ($(origin makedirs_id),environment)
+
+  # the parent of this shell is the "root" make invocation
+  override makedirs_id:=makedirs_$(shell echo $$PPID)
+
+  # makes makedirs_id an environment var
+  export makedirs_id
+
+endif
 
 endif # ifneq ($(strip $(MAKEDIRS)$(MAKEDIR_TARGETS)),)
 
+#
+# MAKEDIRS section
+#
 ifdef MAKEDIRS
 
 .PHONY: makedirs
-
-# The way we make a MAKEDIR
-define makedirs-make
-	$(MAKE) -C $1
-
-endef # makedirs-make
 
 # simple dependency make snippet, scoped to makedirs
 define makedirs-depends
@@ -57,34 +63,61 @@ $1: | makedirs
 endef # makedirs-depends
 
 # Use brute force: before any compilation, all _OBJECTS depend on makedirs
+#  wish there were something in automake that meant "please do first"...
 $(foreach objects,$(filter %_OBJECTS,$(.VARIABLES)),\
    $(foreach object,$($(objects)),\
    $(eval $(call makedirs-depends,$(object)))))
 
-makedirs: $(makedirs_id)
-	$(foreach dir,$(MAKEDIRS),$(call makedirs-make,$(dir)))
+# This says chunk says:
+#  1. makedirs (the order-only PHONY target above) depends on the file
+#       makedirs_id in each of the MAKEDIR directories
+#  2. build $(makedir_id) by running make, then touching the id file
+#  3. clean and distclean should whack all makedir_id files that might
+#       have accumulated
+define makedirs-makedir-rules
+makedirs: $1/$(makedirs_id)
 
-$(makedirs_id):
-	$(NL_V_AT)touch $@
-	$(NL_V_AT)$(RM) $(filter-out $@,$(wildcard makedirs_*))
+$1/$(makedirs_id):
+	$(NL_V_AT)$(MAKE) -C $1
+	$(NL_V_AT)touch $$@
+	$(NL_V_AT)$(RM) $$(filter-out $$@,$$(wildcard $1/makedirs_*))
 
-.PHONY: makedirs_clean
-distclean clean: makedirs_clean
+$1/makedirs_clean:
+	$(NL_V_AT)$(RM) $$(wildcard $1/makedirs_*)
 
-makedirs_clean:
-	$(NL_V_AT)$(RM) $(wildcard makedirs_*)
+.PHONY: $1/makedirs_clean
+distclean clean: $1/makedirs_clean
+
+endef # define makedirs-makedir-rules
+
+# run the above chunk for each MAKEDIR
+$(foreach dir,$(MAKEDIRS),\
+	$(eval $(call makedirs-makedir-rules,$(dir))))
+
 
 endif # ifdef MAKEDIRS
 
+
+#
+# MAKEDIR_TARGETS section
+#
 ifdef MAKEDIR_TARGETS
-# The way me make a MAKEDIR_TARGET
-define makedirs-makedir-target-rule
+
+# This chunk says:
+#  1. the target ($1 in this function) depends on the target's
+#       makedir_id file in its directory
+#  2. build the target with make
+#  2. build the target's makedir_id by touching the id file (and
+#       whacking any leftovers, accumulated ones)
+#  3. clean and distclean should whack all makedir_id files that might
+#       have accumulated
+define makedirs-makedir-target-rules
 $1: $(notdir $1).$(makedirs_id)
-	$(MAKE) -C $(dir $1) $(notdir $1)
+	$(NL_V_AT)$(MAKE) -C $(dir $1) $(notdir $1)
 
 $(notdir $1).$(makedirs_id):
 	$(NL_V_AT)touch $$@
-	$(NL_V_AT)$(RM) $(filter-out $$@,$$(wildcard $(notdir $1).makedirs_*))
+	$(NL_V_AT)$(RM) $$(filter-out $$@,$$(wildcard $(notdir $1).makedirs_*))
 
 .PHONY: $(notdir $1).makedirs_clean
 distclean clean: $(notdir $1).makedirs_clean
@@ -92,9 +125,10 @@ distclean clean: $(notdir $1).makedirs_clean
 $(notdir $1).makedirs_clean:
 	$(NL_V_AT)$(RM) $$(wildcard $(notdir $1).makedirs_*)
 
-endef # makedirs-makedir-target-rule
+endef # makedirs-makedir-target-rules
 
+# invoke the chunk above for each of the MAKEDIR_TARGETS
 $(foreach makedir_target,$(MAKEDIR_TARGETS),\
-   $(eval $(call makedirs-makedir-target-rule,$(makedir_target))))
+   $(eval $(call makedirs-makedir-target-rules,$(makedir_target))))
 
 endif # ifdef MAKEDIR_TARGETS

--- a/automake/post/rules/makedirs.am
+++ b/automake/post/rules/makedirs.am
@@ -69,7 +69,7 @@ $(makedirs_id):
 	$(NL_V_AT)$(RM) $(filter-out $@,$(wildcard makedirs_*))
 
 .PHONY: makedirs_clean
-clean: makedirs_clean
+distclean clean: makedirs_clean
 
 makedirs_clean:
 	$(NL_V_AT)$(RM) $(wildcard makedirs_*)
@@ -87,7 +87,7 @@ $(notdir $1).$(makedirs_id):
 	$(NL_V_AT)$(RM) $(filter-out $$@,$$(wildcard $(notdir $1).makedirs_*))
 
 .PHONY: $(notdir $1).makedirs_clean
-clean: $(notdir $1).makedirs_clean
+distclean clean: $(notdir $1).makedirs_clean
 
 $(notdir $1).makedirs_clean:
 	$(NL_V_AT)$(RM) $$(wildcard $(notdir $1).makedirs_*)

--- a/automake/post/rules/makedirs.am
+++ b/automake/post/rules/makedirs.am
@@ -65,8 +65,14 @@ makedirs: $(makedirs_id)
 	$(foreach dir,$(MAKEDIRS),$(call makedirs-make,$(dir)))
 
 $(makedirs_id):
-	@touch $@
-	@$(RM) $(filter-out $@,$(wildcard makedirs_*))
+	$(NL_V_AT)touch $@
+	$(NL_V_AT)$(RM) $(filter-out $@,$(wildcard makedirs_*))
+
+.PHONY: makedirs_clean
+clean: makedirs_clean
+
+makedirs_clean:
+	$(NL_V_AT)$(RM) $(wildcard makedirs_*)
 
 endif # ifdef MAKEDIRS
 
@@ -77,8 +83,15 @@ $1: $(notdir $1).$(makedirs_id)
 	$(MAKE) -C $(dir $1) $(notdir $1)
 
 $(notdir $1).$(makedirs_id):
-	@touch $$@
-	@$(RM) $(filter-out $$@,$$(wildcard $(notdir $1).makedirs_*))
+	$(NL_V_AT)touch $$@
+	$(NL_V_AT)$(RM) $(filter-out $$@,$$(wildcard $(notdir $1).makedirs_*))
+
+.PHONY: $(notdir $1).makedirs_clean
+clean: $(notdir $1).makedirs_clean
+
+$(notdir $1).makedirs_clean:
+	$(NL_V_AT)$(RM) $$(wildcard $(notdir $1).makedirs_*)
+
 endef # makedirs-makedir-target-rule
 
 $(foreach makedir_target,$(MAKEDIR_TARGETS),\


### PR DESCRIPTION
#### Problem
 MAKEDIRS is too aggressive about "force", which leads rebuilds of targets
  within a call to $(MAKE)

 #### Summary of changes
 create a tagfile for each makedirs target to reduce remakes to a single
  call per invocation of $(MAKE) instead of using force