### PR TITLE
clean-repos: Don't delete submodules from index with "clone" method

### DIFF
--- a/make/post/rules/repos.mak
+++ b/make/post/rules/repos.mak
@@ -175,10 +175,9 @@ clean-repos-local: clean-repos-hook
 		$(RM) -r $(addprefix $(top_srcdir)/,$(REPO_PATHS)); \
 		$(RMDIR) -p $(addprefix $(top_srcdir),$(dir $(REPO_PATHS))) 2> /dev/null || true; \
 		$(RM) -r $(REPO_CACHES) 2> /dev/null;; \
-	    clone) $(GIT) -C $(top_srcdir) rm -rf -q --cached $(REPO_PATHS) 2> /dev/null || true; \
-		$(RM) $(REPOS_WARNING_SENTINEL); \
+	    clone) $(RM) $(REPOS_WARNING_SENTINEL); \
 		$(RM) -r $(addprefix $(top_srcdir)/,$(REPO_PATHS)); \
-		$(RMDIR) -p $(addprefix $(top_srcdir),$(dir $(REPO_PATHS))) 2> /dev/null || true;; \
+		$(MKDIR) -p $(addprefix $(top_srcdir),$(REPO_PATHS)) || true;; \
             *) echo "$(REPOS_CONFIG): Unknown or unsupported pull method '$(REPOS_PULL_METHOD)'.";; \
 	esac
 


### PR DESCRIPTION
With pull.method == clone, nlbuild-autotools doesn't require a git repo
in the parent project. So don't run git commands there.

This fixes an incompatibility between the clone method and submodules
where cleaning will leave staged deletions in the index.