### PR TITLE
Use Sort on PRETTY_FILES to Avoid Duplicates

### DIFF
--- a/automake/pre/macros/pretty.am
+++ b/automake/pre/macros/pretty.am
@@ -40,7 +40,7 @@ am__v_PRETTY_CHECK_1 =
 # This defaults to SOURCES and HEADERS and may be overriden or
 # appended to.
 
-PRETTY_FILES    ?= $(SOURCES) $(HEADERS)
+PRETTY_FILES    ?= $(sort $(SOURCES) $(HEADERS))
 
 # PRETTY_SUBDIRS
 #


### PR DESCRIPTION
This addresses issue #71 by sorting `SOURCES` and `HEADERS` to deduplicate any repeated file paths.